### PR TITLE
Handle nil Rails.application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.1.1] - 2021-03-15
+
+- Handle `nil` `Rails.application`
+
 ## [0.1.0] - 2021-03-05
 
 - Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    container_config (0.1.0)
+    container_config (0.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/container_config/provider/rails_credential.rb
+++ b/lib/container_config/provider/rails_credential.rb
@@ -24,7 +24,7 @@ module ContainerConfig
       #
       def load(key, *dig_keys, **options)
         super
-        ::Rails.application.credentials.config.dig(*dig_keys.map(&:to_sym))
+        ::Rails.application&.credentials&.config&.dig(*dig_keys.map(&:to_sym))
       end
     end
   end

--- a/lib/container_config/version.rb
+++ b/lib/container_config/version.rb
@@ -2,5 +2,5 @@
 
 module ContainerConfig
   # ContainerConfig version
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/container_config/provider/rails_credential_spec.rb
+++ b/spec/container_config/provider/rails_credential_spec.rb
@@ -20,5 +20,16 @@ RSpec.describe ContainerConfig::Provider::RailsCredential do
       expect(subject.load("NOTHING", "nothing")).to eq(nil)
       expect(subject.load("TEST_VAR", "test", "var")).to eq("from_creds")
     end
+
+    context "when Rails.application is nil" do
+      before do
+        allow(Rails).to receive(:application).and_return(nil)
+      end
+
+      it "returns nil" do
+        expect(subject.load("NOTHING")).to eq(nil)
+        expect(subject.load("TEST_VAR")).to eq(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
* Handle the `undefined method 'credentials' for nil:NilClass` error
when the rails gem is required but ContainerConfig is not being used
within the context of a Rails application.