### PR TITLE
Resolve rexml vulnerability CVE-2021-28965

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
 
 Style/StringLiterals:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.1.2] - 2021-05-01
+
+- Resolve rexml vulnerability CVE-2021-28965
+
 ## [0.1.1] - 2021-03-15
 
 - Handle `nil` `Rails.application`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    container_config (0.1.1)
+    container_config (0.1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -9,12 +9,12 @@ GEM
     ast (2.4.2)
     diff-lcs (1.4.4)
     parallel (1.20.1)
-    parser (3.0.0.0)
+    parser (3.0.1.0)
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.1.1)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -28,7 +28,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.11.0)
+    rubocop (1.13.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -41,7 +41,7 @@ GEM
       parser (>= 2.7.1.5)
     rubocop-rake (0.5.1)
       rubocop
-    rubocop-rspec (2.2.0)
+    rubocop-rspec (2.3.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
@@ -61,4 +61,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.2.9
+   2.2.14

--- a/container_config.gemspec
+++ b/container_config.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Loads container configuration values from environment variables, secrets, and credentials."
   spec.homepage      = "https://github.com/wheatevo/container_config"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/wheatevo/container_config"

--- a/lib/container_config/version.rb
+++ b/lib/container_config/version.rb
@@ -2,5 +2,5 @@
 
 module ContainerConfig
   # ContainerConfig version
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
This change resolves rexml vulnerability CVE-2021-28965 by updating gem
dependencies. Updates have also been made to require ruby 2.5+.