### PR TITLE
Demote no key found log to debug log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.1.3] - 2021-06-18
+
+- Demoted `Could not find value for key` log message to debug level
+
 ## [0.1.2] - 2021-05-01
 
 - Resolve rexml vulnerability CVE-2021-28965

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    container_config (0.1.2)
+    container_config (0.1.3)
 
 GEM
   remote: https://rubygems.org/
@@ -9,7 +9,7 @@ GEM
     ast (2.4.2)
     diff-lcs (1.4.4)
     parallel (1.20.1)
-    parser (3.0.1.0)
+    parser (3.0.1.1)
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (13.0.3)
@@ -28,20 +28,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.13.0)
+    rubocop (1.17.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.2.0, < 2.0)
+      rubocop-ast (>= 1.7.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.4.1)
-      parser (>= 2.7.1.5)
+    rubocop-ast (1.7.0)
+      parser (>= 3.0.1.1)
     rubocop-rake (0.5.1)
       rubocop
-    rubocop-rspec (2.3.0)
+    rubocop-rspec (2.4.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
@@ -61,4 +61,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.2.14
+   2.2.16

--- a/lib/container_config.rb
+++ b/lib/container_config.rb
@@ -154,7 +154,7 @@ module ContainerConfig
     def handle_empty_value(config_value, key, **options)
       if config_value.nil? || config_value.to_s.empty?
         provider_list = providers.map(&:name).join(", ")
-        logger.warn { "Could not find value for #{key} in providers: #{provider_list}" }
+        logger.debug { "Could not find value for #{key} in providers: #{provider_list}" }
         raise MissingRequiredValue, "Could not find value for #{key} in providers: #{provider_list}!" if options[:required]
       else
         logger.debug { "Configuration value for #{key} loaded" }

--- a/lib/container_config/version.rb
+++ b/lib/container_config/version.rb
@@ -2,5 +2,5 @@
 
 module ContainerConfig
   # ContainerConfig version
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Demote the no key found log message to debug log level to cut down on
the amount of log chatter from this gem. Consumers that would like to
have more visible errors may pass the `:required` or `:raise` option to the
`#load` method.