### PR TITLE
Add Redis DB flexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.2.0] - 2021-07-20
+
+- Added `db` key to Redis config
+
 ## [0.1.3] - 2021-06-18
 
 - Demoted `Could not find value for key` log message to debug level

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    container_config (0.1.3)
+    container_config (0.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -9,10 +9,10 @@ GEM
     ast (2.4.2)
     diff-lcs (1.4.4)
     parallel (1.20.1)
-    parser (3.0.1.1)
+    parser (3.0.2.0)
       ast (~> 2.4.1)
     rainbow (3.0.0)
-    rake (13.0.3)
+    rake (13.0.6)
     regexp_parser (2.1.1)
     rexml (3.2.5)
     rspec (3.10.0)
@@ -28,7 +28,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.17.0)
+    rubocop (1.18.3)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -37,10 +37,10 @@ GEM
       rubocop-ast (>= 1.7.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.7.0)
+    rubocop-ast (1.8.0)
       parser (>= 3.0.1.1)
-    rubocop-rake (0.5.1)
-      rubocop
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
     rubocop-rspec (2.4.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)

--- a/lib/container_config/redis.rb
+++ b/lib/container_config/redis.rb
@@ -23,12 +23,14 @@ module ContainerConfig
       url = ContainerConfig.load("#{key}_URL", **options, default: "redis://#{host}:#{port}")
       sentinels = sentinel_info(key, **options)
       password = ContainerConfig.load("#{key}_PASSWORD", **options)
+      db = ContainerConfig.load("#{key}_DB", **options, type: :integer, coerce_nil: false)
 
       # Ensure we never pass an empty string to Redis since it will be passed to the Redis AUTH
       # command as-is and will cause an exception
       password = nil if password.to_s.strip.empty?
 
       redis_config = { url: url, password: password }
+      redis_config[:db] = db if db
       redis_config[:sentinels] = sentinels unless sentinels.empty?
 
       # Add SSL configuration

--- a/lib/container_config/version.rb
+++ b/lib/container_config/version.rb
@@ -2,5 +2,5 @@
 
 module ContainerConfig
   # ContainerConfig version
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end

--- a/spec/container_config/redis_spec.rb
+++ b/spec/container_config/redis_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe ContainerConfig::Redis do
 
     context "when single node config is specified" do
       before do
-        stub_const("ENV", { "TEST_HOST" => "test" })
+        stub_const("ENV", { "TEST_HOST" => "test", "TEST_DB" => "3" })
       end
 
       it "returns the single node config" do
         expect(described_class.load("TEST")).to eq(
-          { url: "redis://test:6379", password: nil, ssl: false, ssl_params: {} }
+          { url: "redis://test:6379", password: nil, ssl: false, ssl_params: {}, db: 3 }
         )
       end
     end


### PR DESCRIPTION
This change allows the <KEY>_DB environment variable to be used to set
the Redis database number for the associated Redis configuration.